### PR TITLE
Fix: ignore tokens in target tensor should be set to -100, not -1

### DIFF
--- a/run.py
+++ b/run.py
@@ -345,7 +345,7 @@ def mask_tokens(inputs, tokenizer, mlm_probability=0.15):
     probability_matrix.masked_fill_(torch.tensor(labels == 0, dtype=torch.bool), value=0.0)
 
     masked_indices = torch.bernoulli(probability_matrix).bool()
-    labels[~masked_indices] = -1  # We only compute loss on masked tokens
+    labels[~masked_indices] = -100  # We only compute loss on masked tokens
 
     # 80% of the time, we replace masked input tokens with tokenizer.mask_token ([MASK])
     indices_replaced = torch.bernoulli(torch.full(labels.shape, 0.8)).bool() & masked_indices


### PR DESCRIPTION
Loss cannot be computed if  labels[~masked_indices] = -1.
From BertForMaskedLM documentation: "Indices should be in [-100, 0, ..., config.vocab_size] ... Tokens with indices set to -100 are ignored (masked), the loss is only computed for the tokens with labels in [0, ..., config.vocab_size]"